### PR TITLE
Added basic detection of an executable in the completion.

### DIFF
--- a/timelog_completion
+++ b/timelog_completion
@@ -4,16 +4,24 @@
 # * tl.py category <TAB>    - completes colon (:)
 # * tl.py category : <TAB>  - completes with tasks list in a given category
 
-TL=tl.py
+_TIMELOG=tl.py
+
+if which tl 2>&1 > /dev/null; then
+    _TIMELOG=tl
+else
+if which tl.py 2>&1 > /dev/null; then
+    _TIMELOG=tl.py
+fi
+fi
 
 _print_categories()
 {
-    $TL -c -r
+    $_TIMELOG -c -r
 }
 
 _print_tasks()
 {
-    $TL -r -t $1
+    $_TIMELOG -r -t $1
 }
 
 _timelog()
@@ -58,4 +66,4 @@ _timelog()
     esac
 }
 
-complete -F _timelog $TL
+complete -F _timelog $_TIMELOG


### PR DESCRIPTION
Hi,
I have made an attempt to fix the bash completion.
The previous version was based on an assumption that the script is named tl.py and is available in PATH. In this version I check whether it is tl or tl.py.

If it does not work for you we may still need to change something. A good test would be to try to run e.g. _print_categories function after sourcing it.
